### PR TITLE
TLS1.2

### DIFF
--- a/camect/__init__.py
+++ b/camect/__init__.py
@@ -166,7 +166,7 @@ class Home:
         return base64.b64encode(f"{self._user}:{self._password}".encode()).decode()
 
     async def _event_handler(self):
-        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
         context.verify_mode = ssl.CERT_NONE
         authorization = "Basic " + self._authorization()
         while(True):


### PR DESCRIPTION
TLS 1.0 is deprecated and has recently been disabled on Camect devices, TLS 1.2 should be used instead.